### PR TITLE
fix wrong getCoord further

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1849,9 +1849,9 @@ public class BoardRenderer {
         // KataGo's estimates are for player to move, not for black.
         if (!Lizzie.board.getHistory().isBlacksTurn()) estimate = -estimate;
       }
-      int[] c = Lizzie.board.getCoord(i);
-      int x = c[1];
-      int y = c[0];
+      int[] c = Lizzie.board.getCoordKataGo(i);
+      int x = c[0];
+      int y = c[1];
       int stoneX = scaledMarginWidth + squareWidth * x;
       int stoneY = scaledMarginHeight + squareHeight * y;
       // g.setColor(Color.BLACK);

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -88,8 +88,14 @@ public class Board implements LeelazListener {
   }
 
   public static int[] getCoord(int index) {
-    int y = index % Board.boardWidth;
-    int x = (index - y) / Board.boardWidth;
+    int y = index % Board.boardHeight;
+    int x = (index - y) / Board.boardHeight;
+    return new int[] {x, y};
+  }
+
+  public static int[] getCoordKataGo(int index) {
+    int x = index % Board.boardWidth;
+    int y = (index - x) / Board.boardWidth;
     return new int[] {x, y};
   }
 


### PR DESCRIPTION
(for https://github.com/featurecat/lizzie/pull/827)

Lizzie and KataGo use different orders in serializations of 2D arrays. So we need different getCoord for Lizzie and KataGo.

Your code seems to have unwilling side effects in Lizzie.

* Original code: y = 0, 1, ..., boardHeight - 1.
* Your code: y = 0, 1, ..., boardWidth - 1.

The former seems right for Lizzie.
